### PR TITLE
save and load minimap textures from files

### DIFF
--- a/ValheimPerformanceOptimizations/MinimapPatches.cs
+++ b/ValheimPerformanceOptimizations/MinimapPatches.cs
@@ -1,0 +1,69 @@
+﻿using System.Diagnostics;
+using System.IO;
+using System.Reflection;
+using System.Threading.Tasks;
+using HarmonyLib;
+using UnityEngine;
+using Debug = UnityEngine.Debug;
+
+namespace ValheimPerformanceOptimizations
+{
+    /// <summary>
+    /// Generating the minimap takes a lot of time at startup and is generated from WorldGenerator. Therefore the
+    /// minimap never changes in a given world.
+    /// Now it is being saved inside the world folder as PNGs (there are multiple for different masks). The file names
+    /// are worldName_worldSeed_gameVersion_textureType.png
+    /// </summary>
+    [HarmonyPatch(typeof(Minimap), "GenerateWorldMap")]
+    public static class MinimapPatches
+    {
+        private static bool Prefix(Minimap __instance)
+        {
+            // try to load existing textures
+            if (File.Exists(ForestMaskTexturePath()) && File.Exists(MapTexturePath()) && File.Exists(HeightTexturePath()))
+            {
+                __instance.m_forestMaskTexture.LoadImage(File.ReadAllBytes(ForestMaskTexturePath()));
+                __instance.m_mapTexture.LoadImage(File.ReadAllBytes(MapTexturePath()));
+                __instance.m_heightTexture.LoadRawTextureData(File.ReadAllBytes(HeightTexturePath()));
+                return false;
+            }
+
+            // compute textures normally
+            return true;
+        }
+
+        private static void Postfix(Minimap __instance)
+        {
+            // write computed files to file
+            Directory.CreateDirectory(GetMinimapSavePath());
+            File.WriteAllBytes(ForestMaskTexturePath(), __instance.m_forestMaskTexture.EncodeToPNG());
+            File.WriteAllBytes(MapTexturePath(), __instance.m_mapTexture.EncodeToPNG());
+            File.WriteAllBytes(HeightTexturePath(), __instance.m_heightTexture.EncodeToPNG());
+        }
+
+        public static string GetMinimapSavePath()
+        {
+            return World.GetWorldSavePath() + "/minimap";
+        }
+
+        public static string GetBaseFileName()
+        {
+            return ZNet.m_world.m_name + "_" + ZNet.m_world.m_seed + "_" + Version.GetVersionString();
+        }
+
+        public static string ForestMaskTexturePath()
+        {
+            return GetMinimapSavePath() + "/" + GetBaseFileName() + "_forestMaskTexture.png";
+        }
+
+        public static string MapTexturePath()
+        {
+            return GetMinimapSavePath() + "/" + GetBaseFileName() + "_mapTexture.png";
+        }
+
+        public static string HeightTexturePath()
+        {
+            return GetMinimapSavePath() + "/" + GetBaseFileName() + "_heightTexture.png";
+        }
+    }
+}

--- a/ValheimPerformanceOptimizations/MinimapPatches.cs
+++ b/ValheimPerformanceOptimizations/MinimapPatches.cs
@@ -16,7 +16,7 @@ namespace ValheimPerformanceOptimizations
         private static bool Prefix(Minimap __instance)
         {
             // try to load existing textures
-            if (File.Exists(ForestMaskTexturePath()) && File.Exists(MapTexturePath()) && File.Exists(HeightTexturePath()))
+            if (ImageFilesExists())
             {
                 __instance.m_forestMaskTexture.LoadImage(File.ReadAllBytes(ForestMaskTexturePath()));
                 __instance.m_mapTexture.LoadImage(File.ReadAllBytes(MapTexturePath()));
@@ -30,11 +30,21 @@ namespace ValheimPerformanceOptimizations
 
         private static void Postfix(Minimap __instance)
         {
-            // write computed files to file
-            Directory.CreateDirectory(GetMinimapSavePath());
-            File.WriteAllBytes(ForestMaskTexturePath(), __instance.m_forestMaskTexture.EncodeToPNG());
-            File.WriteAllBytes(MapTexturePath(), __instance.m_mapTexture.EncodeToPNG());
-            File.WriteAllBytes(HeightTexturePath(), __instance.m_heightTexture.EncodeToPNG());
+            if (!ImageFilesExists())
+            {
+                // write computed files to file
+                Directory.CreateDirectory(GetMinimapSavePath());
+                File.WriteAllBytes(ForestMaskTexturePath(), __instance.m_forestMaskTexture.EncodeToPNG());
+                File.WriteAllBytes(MapTexturePath(), __instance.m_mapTexture.EncodeToPNG());
+                File.WriteAllBytes(HeightTexturePath(), __instance.m_heightTexture.GetRawTextureData());
+            }
+        }
+
+        public static bool ImageFilesExists()
+        {
+            return File.Exists(ForestMaskTexturePath()) &&
+                   File.Exists(MapTexturePath()) &&
+                   File.Exists(HeightTexturePath());
         }
 
         public static string GetMinimapSavePath()
@@ -59,7 +69,7 @@ namespace ValheimPerformanceOptimizations
 
         public static string HeightTexturePath()
         {
-            return GetMinimapSavePath() + "/" + GetBaseFileName() + "_heightTexture.png";
+            return GetMinimapSavePath() + "/" + GetBaseFileName() + "_heightTexture.raw";
         }
     }
 }

--- a/ValheimPerformanceOptimizations/MinimapPatches.cs
+++ b/ValheimPerformanceOptimizations/MinimapPatches.cs
@@ -1,10 +1,6 @@
-﻿using System.Diagnostics;
-using System.IO;
-using System.Reflection;
-using System.Threading.Tasks;
+﻿using System.IO;
 using HarmonyLib;
 using UnityEngine;
-using Debug = UnityEngine.Debug;
 
 namespace ValheimPerformanceOptimizations
 {

--- a/ValheimPerformanceOptimizations/MinimapPatches.cs
+++ b/ValheimPerformanceOptimizations/MinimapPatches.cs
@@ -1,4 +1,5 @@
 ﻿using System.IO;
+using System.IO.Compression;
 using HarmonyLib;
 using UnityEngine;
 
@@ -7,8 +8,7 @@ namespace ValheimPerformanceOptimizations
     /// <summary>
     /// Generating the minimap takes a lot of time at startup and is generated from WorldGenerator. Therefore the
     /// minimap never changes in a given world.
-    /// Now it is being saved inside the world folder as PNGs (there are multiple for different masks). The file names
-    /// are worldName_worldSeed_gameVersion_textureType.png
+    /// Now it is being saved inside the world folder as a zipped file with the name worldName_worldSeed_gameVersion.map
     /// </summary>
     [HarmonyPatch(typeof(Minimap), "GenerateWorldMap")]
     public static class MinimapPatches
@@ -16,11 +16,9 @@ namespace ValheimPerformanceOptimizations
         private static bool Prefix(Minimap __instance)
         {
             // try to load existing textures
-            if (ImageFilesExists())
+            if (File.Exists(FilePath()))
             {
-                __instance.m_forestMaskTexture.LoadImage(File.ReadAllBytes(ForestMaskTexturePath()));
-                __instance.m_mapTexture.LoadImage(File.ReadAllBytes(MapTexturePath()));
-                __instance.m_heightTexture.LoadRawTextureData(File.ReadAllBytes(HeightTexturePath()));
+                LoadFromFile(__instance);
                 return false;
             }
 
@@ -30,46 +28,56 @@ namespace ValheimPerformanceOptimizations
 
         private static void Postfix(Minimap __instance)
         {
-            if (!ImageFilesExists())
+            if (!File.Exists(FilePath()))
             {
-                // write computed files to file
-                Directory.CreateDirectory(GetMinimapSavePath());
-                File.WriteAllBytes(ForestMaskTexturePath(), __instance.m_forestMaskTexture.EncodeToPNG());
-                File.WriteAllBytes(MapTexturePath(), __instance.m_mapTexture.EncodeToPNG());
-                File.WriteAllBytes(HeightTexturePath(), __instance.m_heightTexture.GetRawTextureData());
+                // write computed textures to file
+                Directory.CreateDirectory(MinimapSaveFolderPath());
+                SaveToFile(__instance);
             }
         }
 
-        public static bool ImageFilesExists()
+        private static void SaveToFile(Minimap minimap)
         {
-            return File.Exists(ForestMaskTexturePath()) &&
-                   File.Exists(MapTexturePath()) &&
-                   File.Exists(HeightTexturePath());
+            using (FileStream fileStream = File.Create(FilePath()))
+            using (GZipStream compressionStream = new GZipStream(fileStream, CompressionMode.Compress))
+            {
+                ZPackage package = new ZPackage();
+                package.Write(minimap.m_forestMaskTexture.GetRawTextureData());
+                package.Write(minimap.m_mapTexture.GetRawTextureData());
+                package.Write(minimap.m_heightTexture.GetRawTextureData());
+
+                byte[] data = package.GetArray();
+                compressionStream.Write(data, 0, data.Length);
+            }
         }
 
-        public static string GetMinimapSavePath()
+        private static void LoadFromFile(Minimap minimap)
+        {
+            using (FileStream fileStream = File.OpenRead(FilePath()))
+            using (GZipStream decompressionStream = new GZipStream(fileStream, CompressionMode.Decompress))
+            using (MemoryStream resultStream = new MemoryStream())
+            {
+                decompressionStream.CopyTo(resultStream);
+                ZPackage package = new ZPackage(resultStream.ToArray());
+
+                minimap.m_forestMaskTexture.LoadRawTextureData(package.ReadByteArray());
+                minimap.m_forestMaskTexture.Apply();
+                minimap.m_mapTexture.LoadRawTextureData(package.ReadByteArray());
+                minimap.m_mapTexture.Apply();
+                minimap.m_heightTexture.LoadRawTextureData(package.ReadByteArray());
+                minimap.m_heightTexture.Apply();
+            }
+        }
+
+        public static string FilePath()
+        {
+            string file = ZNet.m_world.m_name + "_" + ZNet.m_world.m_seed + "_" + Version.GetVersionString() + ".map";
+            return MinimapSaveFolderPath() + "/" + file;
+        }
+
+        public static string MinimapSaveFolderPath()
         {
             return World.GetWorldSavePath() + "/minimap";
-        }
-
-        public static string GetBaseFileName()
-        {
-            return ZNet.m_world.m_name + "_" + ZNet.m_world.m_seed + "_" + Version.GetVersionString();
-        }
-
-        public static string ForestMaskTexturePath()
-        {
-            return GetMinimapSavePath() + "/" + GetBaseFileName() + "_forestMaskTexture.png";
-        }
-
-        public static string MapTexturePath()
-        {
-            return GetMinimapSavePath() + "/" + GetBaseFileName() + "_mapTexture.png";
-        }
-
-        public static string HeightTexturePath()
-        {
-            return GetMinimapSavePath() + "/" + GetBaseFileName() + "_heightTexture.raw";
         }
     }
 }


### PR DESCRIPTION
I have tried many thinks to speed up computation time of startup but nothing really worked and it required much work. So I decided to just skip some process time :)

On every startup the minimap is rendered. It is not done with a shader but with expensive cpu rendering. These images never change and much time is wasted. Now the minimap textures are saved into files and saved as `worldName_worldSeed_gameVersion_textureType.png` into `AppData/.../Valheim/worlds/minimap`. Therefore is insured to be unique for every world and if an update changes the world gen new images are always generated. All three textures combined are ~under 1MB~ about 16MB. On my machine this saves about 20 seconds startup time! (10 seconds when you aren't in development build)

You need to add `UnityEngine.ImageConversionModule.dll` as a dependency, I haven't added in the commits because my paths are completely different.