### PR TITLE
calculate rested bonus only with pieces that impact comfort

### DIFF
--- a/ValheimPerformanceOptimizations/PiecePatches.cs
+++ b/ValheimPerformanceOptimizations/PiecePatches.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.Linq;
 using HarmonyLib;
 using UnityEngine;
 
@@ -30,6 +31,43 @@ namespace ValheimPerformanceOptimizations
             }
 
             return false;
+        }
+    }
+
+    [HarmonyPatch]
+    public static class AllComfortPieces
+    {
+        public static Dictionary<int, Piece> allComfortPieces = new Dictionary<int, Piece>();
+
+        [HarmonyPatch(typeof(Piece), "Awake"), HarmonyPostfix]
+        public static void AwakePatch(Piece __instance)
+        {    
+            if (Piece.ghostLayer == 0)
+            {
+                Piece.ghostLayer = LayerMask.NameToLayer("ghost");
+            }
+
+            if (__instance.gameObject.layer != Piece.ghostLayer && __instance.m_comfort != 0)
+            {
+                allComfortPieces.Add(__instance.GetInstanceID(), __instance);
+            }
+        }
+
+        [HarmonyPatch(typeof(Piece), "OnDestroy"), HarmonyPostfix]
+        public static void OnDestroyPatch(Piece __instance)
+        {
+            if(allComfortPieces.ContainsKey(__instance.GetInstanceID()))
+            {
+                allComfortPieces.Remove(__instance.GetInstanceID());
+            }
+        }
+
+        public static List<Piece> GetNearbyComfortPieces(Vector3 position)
+        {
+            const float sqrRadius = 10 * 10;
+            return allComfortPieces
+                   .Where(pair => Vector3.SqrMagnitude(position - pair.Value.transform.position) < sqrRadius)
+                   .Select(pair => pair.Value).ToList();
         }
     }
 }

--- a/ValheimPerformanceOptimizations/SE_RestedPatches.cs
+++ b/ValheimPerformanceOptimizations/SE_RestedPatches.cs
@@ -26,7 +26,7 @@ namespace ValheimPerformanceOptimizations
             // in shelter one extra comfort
             __result += 1;
 
-            List<Piece> nearbyPieces = SE_Rested.GetNearbyPieces(player.transform.position);
+            List<Piece> nearbyPieces = AllComfortPieces.GetNearbyComfortPieces(player.transform.position);
             var maxByComfortGroup = new Dictionary<Piece.ComfortGroup, int>();
             var unsorted = new Dictionary<string, Piece>();
 


### PR DESCRIPTION
I improved `CalculateComfortLevel` again, now it only takes ~900 ticks (0,09 ms) to calucate it. Only pieces that can impact comfort (`piece.comfort != 0`) are stored and the range is calculated with square distance, so no heavy computing here.
This makes your `GetAllPiecesInRadius` patch currently unused.